### PR TITLE
support custom struct's field tag name

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -4,7 +4,7 @@ package structure
 import "reflect"
 
 var (
-	tagName = "structure" // struct's field default tag name
+	DefaultTagName = "structure" // struct's field default tag name
 )
 
 // Map converts the given s struct to a map[string]interface{}, where the keys
@@ -44,7 +44,7 @@ func Map(s interface{}) map[string]interface{} {
 
 		// override if the user passed a structure tag value
 		// ignore if the user passed the "-" value
-		if tag := field.Tag.Get(tagName); tag != "" {
+		if tag := field.Tag.Get(DefaultTagName); tag != "" {
 			name = tag
 		}
 
@@ -198,16 +198,6 @@ func Has(s interface{}, fieldName string) bool {
 	return false
 }
 
-// Set struct's field tag name
-func SetTagName(n string) {
-	tagName = n
-}
-
-// Reset struct's field tag name, default: "structure"
-func ResetTagName() {
-	tagName = "structure"
-}
-
 // strctInfo returns the struct value and the exported struct fields for a
 // given s struct. This is a convenient helper method to avoid duplicate code
 // in some of the functions.
@@ -225,7 +215,7 @@ func strctInfo(s interface{}) (reflect.Value, []reflect.StructField) {
 		}
 
 		// don't check if it's omitted
-		if tag := field.Tag.Get(tagName); tag == "-" {
+		if tag := field.Tag.Get(DefaultTagName); tag == "-" {
 			continue
 		}
 

--- a/structure_test.go
+++ b/structure_test.go
@@ -100,8 +100,11 @@ func TestMap_CustomTag(t *testing.T) {
 		C: true,
 	}
 
-	SetTagName("dd")
-	defer ResetTagName()
+	defaultName := DefaultTagName
+	DefaultTagName = "dd"
+	defer func() {
+		DefaultTagName = defaultName
+	}()
 	a := Map(T)
 
 	inMap := func(key interface{}) bool {


### PR DESCRIPTION
Example:

```
   var T = struct {
            A string `dd:"x"`
            B int    `dd:"y"`
            C bool   `dd:"z"`
    }{
            A: "a-value",
            B: 2,
            C: true,
    }

    SetTagName("dd")
    defer ResetTagName()
    a := Map(T)
    // blabla
```
