### PR TITLE
Use field's index to fetch field's value

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -28,9 +28,9 @@ func Map(s interface{}) map[string]interface{} {
 
 	v, fields := strctInfo(s)
 
-	for i, field := range fields {
+	for _, field := range fields {
 		name := field.Name
-		val := v.Field(i)
+		val := v.FieldByIndex(field.Index)
 
 		var finalVal interface{}
 


### PR DESCRIPTION
I had some crashes on `val.Interface()` with my structures, and worked around those by using `reflect`'s mechanism to obtain field's index. Really hope this can get merged!
