### PR TITLE
Custom default tag name for each struct

### DIFF
--- a/field.go
+++ b/field.go
@@ -92,7 +92,7 @@ func (f *Field) Set(val interface{}) error {
 //
 // It panics if field is not exported or if field's kind is not struct
 func (f *Field) Fields() []*Field {
-	return getFields(f.value)
+	return getFields(f.value, DefaultTagName)
 }
 
 // Field returns the field from a nested struct. It panics if the nested struct

--- a/field.go
+++ b/field.go
@@ -14,8 +14,9 @@ var (
 // Field represents a single struct field that encapsulates high level
 // functions around the field.
 type Field struct {
-	value reflect.Value
-	field reflect.StructField
+	value      reflect.Value
+	field      reflect.StructField
+	defaultTag string
 }
 
 // Tag returns the value associated with key in the tag string. If there is no
@@ -92,7 +93,7 @@ func (f *Field) Set(val interface{}) error {
 //
 // It panics if field is not exported or if field's kind is not struct
 func (f *Field) Fields() []*Field {
-	return getFields(f.value, DefaultTagName)
+	return getFields(f.value, f.defaultTag)
 }
 
 // Field returns the field from a nested struct. It panics if the nested struct

--- a/structs.go
+++ b/structs.go
@@ -222,8 +222,9 @@ func (s *Struct) FieldOk(name string) (*Field, bool) {
 	}
 
 	return &Field{
-		field: field,
-		value: s.value.FieldByName(name),
+		field:      field,
+		value:      s.value.FieldByName(name),
+		defaultTag: s.TagName,
 	}, true
 }
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -124,12 +124,10 @@ func TestMap_CustomTag(t *testing.T) {
 		C: true,
 	}
 
-	defaultName := DefaultTagName
-	DefaultTagName = "dd"
-	defer func() {
-		DefaultTagName = defaultName
-	}()
-	a := Map(T)
+	s := New(T)
+	s.TagName = "dd"
+
+	a := s.Map()
 
 	inMap := func(key interface{}) bool {
 		for k := range a {

--- a/structs_test.go
+++ b/structs_test.go
@@ -146,6 +146,31 @@ func TestMap_CustomTag(t *testing.T) {
 
 }
 
+func TestMap_MultipleCustomTag(t *testing.T) {
+	var A = struct {
+		X string `aa:"ax"`
+	}{"a_value"}
+
+	aStruct := New(A)
+	aStruct.TagName = "aa"
+
+	var B = struct {
+		X string `bb:"bx"`
+	}{"b_value"}
+
+	bStruct := New(B)
+	bStruct.TagName = "bb"
+
+	a, b := aStruct.Map(), bStruct.Map()
+	if !reflect.DeepEqual(a, map[string]interface{}{"ax": "a_value"}) {
+		t.Error("Map should have field ax with value a_value")
+	}
+
+	if !reflect.DeepEqual(b, map[string]interface{}{"bx": "b_value"}) {
+		t.Error("Map should have field bx with value b_value")
+	}
+}
+
 func TestMap_OmitEmpty(t *testing.T) {
 	type A struct {
 		Name  string


### PR DESCRIPTION
I think modifying and using global variable is bad practice. If using this with many custom field tags, it can cause race condition.
So I made change to each struct to have default tag name. It will increase more goroutine safety.

I wanted to eliminate the global DefaultTagName variable, but I didn't since it affects all users watching.
Take a look and advice me if I did wrong.
Thank you!