### PR TITLE
Added simple "to lower case" method.

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -1,7 +1,10 @@
 // Package structs contains various utilities functions to work with structs.
 package structs
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
 var (
 	// DefaultTagName is the default tag name for struct fields which provides
@@ -98,6 +101,23 @@ func (s *Struct) Map() map[string]interface{} {
 		}
 
 		out[name] = finalVal
+	}
+
+	return out
+}
+
+func (s *Struct) LowerCaseMap() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	fields := s.structFields()
+
+	for _, field := range fields {
+		name := field.Name
+		val := s.value.FieldByName(name)
+
+		var finalVal interface{}
+		finalVal = val.Interface()
+		out[strings.ToLower(name)] = finalVal
 	}
 
 	return out
@@ -373,6 +393,10 @@ func strctVal(s interface{}) reflect.Value {
 // refer to Struct types Map() method. It panics if s's kind is not struct.
 func Map(s interface{}) map[string]interface{} {
 	return New(s).Map()
+}
+
+func LowerCaseMap(s interface{}) map[string]interface{} {
+	return New(s).LowerCaseMap()
 }
 
 // Values converts the given struct to a []interface{}. For more info refer to

--- a/structs_test.go
+++ b/structs_test.go
@@ -83,6 +83,59 @@ func TestMap(t *testing.T) {
 
 }
 
+func TestLowerMap(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	a := LowerCaseMap(T)
+
+	if typ := reflect.TypeOf(a).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	// we have three fields
+	if len(a) != 3 {
+		t.Errorf("Map should return a map of len 3, got: %d", len(a))
+	}
+
+	inMap := func(val interface{}) bool {
+		for _, v := range a {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, val := range []interface{}{"a-value", 2, true} {
+		if !inMap(val) {
+			t.Errorf("Map should have the value %v", val)
+		}
+	}
+	keyInMap := func(val interface{}) bool {
+		for i, _ := range a {
+			if reflect.DeepEqual(i, val) {
+				return true
+			}
+		}
+
+		return false
+	}
+	for _, val := range []interface{}{"a", "b", "c"} {
+		if !keyInMap(val) {
+			t.Errorf("Map should have the key %v", val)
+		}
+	}
+
+}
 func TestMap_Tag(t *testing.T) {
 	var T = struct {
 		A string `structs:"x"`


### PR DESCRIPTION
Added very simple method to get a map[string]interface{} from a struct
with the desired keys as lowercase'ed strings from the struct keys.
This allows more flexibly when serializing to json/msgpack.