### PR TITLE
switch travis builds to recommended container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go: 1.5
+sudo: false
 before_install:
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls


### PR DESCRIPTION
Travis complained that builds were running on legacy infrastructure, added `sudo: false` to enable recommended container-based builds.