### PR TITLE
fix nesting of time fields

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -2,7 +2,6 @@
 package structs
 
 import "reflect"
-import "time"
 
 var (
 	// DefaultTagName is the default tag name for struct fields which provides
@@ -90,12 +89,17 @@ func (s *Struct) Map() map[string]interface{} {
 			}
 		}
 
-		if IsStruct(val.Interface()) && !isTime(val.Interface()) && !tagOpts.Has("omitnested") {
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
 			// look out for embedded structs, and convert them to a
 			// map[string]interface{} too
 			n := New(val.Interface())
 			n.TagName = s.TagName
-			finalVal = n.Map()
+			m := n.Map()
+			if len(m) == 0 {
+				finalVal = val.Interface()
+			} else {
+				finalVal = m
+			}
 		} else {
 			finalVal = val.Interface()
 		}
@@ -149,7 +153,7 @@ func (s *Struct) Values() []interface{} {
 			}
 		}
 
-		if IsStruct(val.Interface()) && !isTime(val.Interface()) && !tagOpts.Has("omitnested") {
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
 			// look out for embedded structs, and convert them to a
 			// []interface{} to be added to the final values slice
 			for _, embeddedVal := range Values(val.Interface()) {
@@ -447,9 +451,4 @@ func IsStruct(s interface{}) bool {
 // empty string for unnamed types. It panics if s's kind is not struct.
 func Name(s interface{}) string {
 	return New(s).Name()
-}
-
-func isTime(v interface{}) bool {
-	_, ok := v.(time.Time)
-	return ok
 }

--- a/structs.go
+++ b/structs.go
@@ -2,6 +2,7 @@
 package structs
 
 import "reflect"
+import "time"
 
 var (
 	// DefaultTagName is the default tag name for struct fields which provides
@@ -89,7 +90,7 @@ func (s *Struct) Map() map[string]interface{} {
 			}
 		}
 
-		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+		if IsStruct(val.Interface()) && !isTime(val.Interface()) && !tagOpts.Has("omitnested") {
 			// look out for embedded structs, and convert them to a
 			// map[string]interface{} too
 			n := New(val.Interface())
@@ -148,7 +149,7 @@ func (s *Struct) Values() []interface{} {
 			}
 		}
 
-		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+		if IsStruct(val.Interface()) && !isTime(val.Interface()) && !tagOpts.Has("omitnested") {
 			// look out for embedded structs, and convert them to a
 			// []interface{} to be added to the final values slice
 			for _, embeddedVal := range Values(val.Interface()) {
@@ -446,4 +447,9 @@ func IsStruct(s interface{}) bool {
 // empty string for unnamed types. It panics if s's kind is not struct.
 func Name(s interface{}) string {
 	return New(s).Name()
+}
+
+func isTime(v interface{}) bool {
+	_, ok := v.(time.Time)
+	return ok
 }

--- a/structs_test.go
+++ b/structs_test.go
@@ -296,6 +296,20 @@ func TestMap_Anonymous(t *testing.T) {
 	}
 }
 
+func TestMap_TimeField(t *testing.T) {
+	type A struct {
+		CreatedAt time.Time
+	}
+
+	a := &A{CreatedAt: time.Now().UTC()}
+	m := Map(a)
+
+	_, ok := m["CreatedAt"].(time.Time)
+	if !ok {
+		t.Error("Time field must be final")
+	}
+}
+
 func TestStruct(t *testing.T) {
 	var T = struct{}{}
 


### PR DESCRIPTION
Calling `Map` for struct with `time.Time` fields makes empty map for such fields. I need to keep them untouched automatically without usage of `omitnested` tag.

Also I think `time.Duration` should be included to list of "auto omitnested" types.