### PR TITLE
Fix print verb in a test

### DIFF
--- a/structs_test.go
+++ b/structs_test.go
@@ -1067,7 +1067,7 @@ func TestTagWithStringOption(t *testing.T) {
 
 	vs := s.Values()
 	if vs[1] != person.String() {
-		t.Errorf("Value for 2nd field (person) should be %t, got: %t", person.String(), vs[1])
+		t.Errorf("Value for 2nd field (person) should be %T, got: %T", person.String(), vs[1])
 	}
 }
 


### PR DESCRIPTION
The current verbs print a bool as either `true` or `false`, which does not seem the be the intention and does not match the arguments types.