### PR TITLE
Value tag

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -14,6 +14,10 @@ var (
 	DefaultTagName = "structs" // struct's field default tag name
 )
 
+type Valuer interface {
+	Value() interface{}
+}
+
 // Struct encapsulates a struct type to provide several high level functions
 // around the struct.
 type Struct struct {
@@ -135,6 +139,13 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 			s, ok := val.Interface().(fmt.Stringer)
 			if ok {
 				out[name] = s.String()
+			}
+			continue
+		}
+
+		if tagOpts.Has("value") {
+			if v, ok := val.Interface().(Valuer); ok {
+				out[name] = v.Value()
 			}
 			continue
 		}

--- a/structs.go
+++ b/structs.go
@@ -14,8 +14,9 @@ var (
 	DefaultTagName = "structs" // struct's field default tag name
 )
 
+// Valuer interface could be used to implement custom logic for map convertion.
 type Valuer interface {
-	Valuex() interface{}
+	StructValue() interface{}
 }
 
 // Struct encapsulates a struct type to provide several high level functions
@@ -79,6 +80,12 @@ func New(s interface{}) *Struct {
 //   // Field appears in map as key "Field" (the default), but
 //   // the field is skipped if empty.
 //   Field string `structs:",omitempty"`
+//
+// A tag value with the option of "value" uses Valuer to get the value. Example:
+//
+//	// The value will be the returned value of Animal's StructValue() function.
+//	// Map will ignore the value if Animal does not implement StructValue().
+// 	Field *Animal `structs:",value"`
 //
 // Note that only exported fields of a struct can be accessed, non exported
 // fields will be neglected.
@@ -145,7 +152,7 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 
 		if tagOpts.Has("value") {
 			if v, ok := val.Interface().(Valuer); ok {
-				out[name] = v.Valuex()
+				out[name] = v.StructValue()
 			}
 			continue
 		}

--- a/structs.go
+++ b/structs.go
@@ -15,7 +15,7 @@ var (
 )
 
 type Valuer interface {
-	Value() interface{}
+	Valuex() interface{}
 }
 
 // Struct encapsulates a struct type to provide several high level functions
@@ -145,7 +145,7 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 
 		if tagOpts.Has("value") {
 			if v, ok := val.Interface().(Valuer); ok {
-				out[name] = v.Value()
+				out[name] = v.Valuex()
 			}
 			continue
 		}

--- a/structs_test.go
+++ b/structs_test.go
@@ -1376,3 +1376,49 @@ func TestMap_InterfaceValue(t *testing.T) {
 		t.Errorf("Value does not match expected: %q != %q", s["A"], expected)
 	}
 }
+
+type Cat struct {
+	Animal *Animal `structs:"animal,value"`
+}
+
+func (a *Animal) StructValue() interface{} {
+	return fmt.Sprintf("%s is %d years old", a.Name, a.Age)
+}
+
+func TestMap_Valuer(t *testing.T) {
+	cat := &Cat{
+		Animal: &Animal{
+			Name: "Mimi",
+			Age:  5,
+		},
+	}
+
+	m := Map(cat)
+
+	expected := "Mimi is 5 years old"
+	value := m["animal"]
+
+	if value != expected {
+		t.Errorf("Expected value: %s, got: %s", expected, value)
+	}
+}
+
+func TestMap_ValuerNotImplemented(t *testing.T) {
+	var a = struct {
+		Person *Person `structs:"person,value"`
+	}{
+		Person: &Person{
+			Name: "John",
+			Age:  23,
+		},
+	}
+
+	m := Map(a)
+
+	mapLen := len(m)
+	exptectedLen := 0
+
+	if mapLen != exptectedLen {
+		t.Errorf("Expected length: %d, got: %d", exptectedLen, mapLen)
+	}
+}


### PR DESCRIPTION
Hi Fatih,

I use the structs package for creating a flat map which contains the arguments I need for a named query. See the function https://godoc.org/github.com/jmoiron/sqlx#DB.NamedExec

However I run into issues with for example my NullTime type. My NullTime type is similar to the NullX types in the sql package of the standard library. See for example https://golang.org/pkg/database/sql/#NullBool

I have something like this:

```
type Record struct {
    LastStartAt NullTime
}

type NullTime struct {
    Time time.Time
    Valid bool
}
```

If I create a map from the Record, I would like to get an entry "LastStartAt" with the time.Time value and not a map[string]interface{}.

I saw no way to get this result with the current functionality of the package, so I have implemented support for a "value" tag similar to the already implemented "string" tag.

If the "value" tag is set and the child struct implements the Valuer interface, the return value of the Valuex() function is set in the final map.

So I end up with something like the following and get the map I need. 

```
type Record struct {
    LastStartAt NullTime `structs:",value"`
}

type NullTime struct {
    Time time.Time
    Valid bool
}

func (nt NullTime) Valuex() interface{} {
    return nt.Time
}
```

What do you think about this? Is it something you like to add to the package? If so, I could implement a test and write some documentation.

And if you like it, have you a suggestion for the function name? I'm not very happy with Valuex(), but Value() could not be used because it would result in a conflict if the sql/driver.Valuer interface of the standard library is also implemented by a type.

Best regards,
Marco
