### PR TITLE
Add StringValues() (same as Values() but returns []string intstead of []interface

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -521,6 +521,12 @@ func Values(s interface{}) []interface{} {
 	return New(s).Values()
 }
 
+// StringValues converts the given struct to a []string{}. For more info refer
+// to Struct types StringValues() method.  It panics if s's kind is not struct.
+func StringValues(s interface{}) []string {
+	return New(s).StringValues()
+}
+
 // Fields returns a slice of *Field. For more info refer to Struct types
 // Fields() method.  It panics if s's kind is not struct.
 func Fields(s interface{}) []*Field {


### PR DESCRIPTION
Hello,

I added StringValues() because I needed it for conveniently converting a structs values to []string (for creating CSV rows).

Its basically a duplicate of Values() but returns []string instead of []interface. It also ignores embedded structs as they don't really make sense in the context of []string.

Not sure if this is something you wanted in the base package or not - but if it is let me know and I'll add some tests etc.

Thanks

Andrew