### PR TITLE
fix: panic when passing pointer to pointer as param

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -431,7 +431,7 @@ func strctVal(s interface{}) reflect.Value {
 	v := reflect.ValueOf(s)
 
 	// if pointer get the underlying element≤
-	if v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -1376,3 +1376,24 @@ func TestMap_InterfaceValue(t *testing.T) {
 		t.Errorf("Value does not match expected: %q != %q", s["A"], expected)
 	}
 }
+
+func TestPointer2Pointer(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Internal nil pointer should not panic")
+		}
+	}()
+	a := &Animal{
+		Name: "Fluff",
+		Age:  4,
+	}
+	_ = Map(&a)
+
+	b := &a
+	_ = Map(&b)
+
+	c := &b
+	_ = Map(&c)
+}


### PR DESCRIPTION
Hi, all. Since golang provides syntactic sugar when using pointers, pointer to pointer should be considered legal parameter for structs.New()