### PR TITLE
added dotflatten tag

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -58,6 +58,12 @@ func New(s interface{}) *Struct {
 //   // The FieldStruct's fields will be flattened into the output map.
 //   FieldStruct time.Time `structs:",flatten"`
 //
+// A tag value with the option of "dotflatten" used in a struct field is to flatten its fields separated with dots
+// in the output map in the next format "Structure.Field". Example:
+//
+//   // The FieldStruct's fields will be flattened into the output map.
+//   FieldStruct time.Time `structs:",flatten"`
+//
 // A tag value with the option of "omitnested" stops iterating further if the type
 // is a struct. Example:
 //
@@ -131,21 +137,24 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 			finalVal = val.Interface()
 		}
 
-		if tagOpts.Has("string") {
+		switch {
+		case tagOpts.Has("string"):
 			s, ok := val.Interface().(fmt.Stringer)
 			if ok {
 				out[name] = s.String()
 			}
-			continue
-		}
-
-		if isSubStruct && (tagOpts.Has("flatten")) {
+		case isSubStruct && (tagOpts.Has("flatten")):
 			for k := range finalVal.(map[string]interface{}) {
 				out[k] = finalVal.(map[string]interface{})[k]
 			}
-		} else {
+		case isSubStruct && (tagOpts.Has("dotflatten")):
+			for k := range finalVal.(map[string]interface{}) {
+				out[fmt.Sprintf("%s.%s", field.Name, k)] = finalVal.(map[string]interface{})[k]
+			}
+		default:
 			out[name] = finalVal
 		}
+
 	}
 }
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -585,6 +585,33 @@ func TestMap_Flatnested(t *testing.T) {
 
 }
 
+func TestMap_DotFlatnested(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A `structs:",dotflatten"`
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	m := Map(b)
+
+	_, ok := m["A"].(map[string]interface{})
+	if ok {
+		t.Error("Embedded A struct with tag flatten has to be flat in the map")
+	}
+
+	expectedMap := map[string]interface{}{"A.Name": "example", "C": 123}
+	if !reflect.DeepEqual(m, expectedMap) {
+		t.Errorf("The exprected map %+v does't correspond to %+v", expectedMap, m)
+	}
+
+}
+
 func TestMap_FlatnestedOverwrite(t *testing.T) {
 	type A struct {
 		Name string


### PR DESCRIPTION
Hello, I added functionality to create field names separated by dots in next format "StructName.FieldName". I need this functionality to create meaningful names for InfluxDB keys from big Structures with Substructures.

I'm not sure with the tag name, I called it  "dotflatten" maybe you have better idea how to call it.

Example:

```
	type Person struct {
		Name   string
		Number int
	}

	type Access struct {
		Person        Person `structs:",dotflatten"`
		HasPermission bool
		LastAccessed  time.Time
	}

	s := &Access{
		Person:        Person{Name: "fatih", Number: 1234567},
		LastAccessed:  time.Now(),
		HasPermission: true,
	}

	fmt.Println(structs.Map(s))
	// output map[Person.Name:fatih Person.Number:1234567 HasPermission:true LastAccessed:2016-08-10 23:56:46.473789853 +0300 EEST]
```
