### PR TITLE
struct: add KeyFunc

### DIFF
--- a/field.go
+++ b/field.go
@@ -14,9 +14,10 @@ var (
 // Field represents a single struct field that encapsulates high level
 // functions around the field.
 type Field struct {
-	value      reflect.Value
-	field      reflect.StructField
-	defaultTag string
+	value          reflect.Value
+	field          reflect.StructField
+	defaultTagName string
+	defaultTagFunc TagFunc
 }
 
 // Tag returns the value associated with key in the tag string. If there is no
@@ -100,7 +101,7 @@ func (f *Field) Zero() error {
 //
 // It panics if field is not exported or if field's kind is not struct
 func (f *Field) Fields() []*Field {
-	return getFields(f.value, f.defaultTag)
+	return getFields(f.value, f.defaultTagFunc)
 }
 
 // Field returns the field from a nested struct. It panics if the nested struct

--- a/structs_test.go
+++ b/structs_test.go
@@ -113,6 +113,41 @@ func TestMap_Tag(t *testing.T) {
 
 }
 
+func TestMap_TagFunc(t *testing.T) {
+	var T = struct {
+		A string `json:"x"`
+		B int    `json:"y"`
+		C bool   `json:"z"`
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	s := New(T)
+	s.TagName = "json"
+	s.TagFunc = func(field reflect.StructField) string {
+		return fmt.Sprintf("%s-by-func", field.Tag.Get("json"))
+	}
+
+	a := s.Map()
+
+	inMap := func(key interface{}) bool {
+		for k := range a {
+			if reflect.DeepEqual(k, key) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, key := range []string{"x-by-func", "y-by-func", "z-by-func"} {
+		if !inMap(key) {
+			t.Errorf("Map should have the key %v", key)
+		}
+	}
+}
+
 func TestMap_CustomTag(t *testing.T) {
 	var T = struct {
 		A string `json:"x"`


### PR DESCRIPTION
The KeyFunc allows us to set the keys for each field dynamically.

By default, KeyFunc returns the value specified by the TagName tag.

The arguments to KeyFunc are the field whose key it returns, and the type of its containing struct.

I need to set the keys dynamically when working with the generated Protocol Buffers structs. I am specifying meta information, including keys, as protobuf [field options](https://developers.google.com/protocol-buffers/docs/proto#customoptions) in the proto files. In my usecase, KeyFunc returns the value of the field option.