### PR TITLE
correct printf verb

### DIFF
--- a/structs_test.go
+++ b/structs_test.go
@@ -399,7 +399,7 @@ func TestMap_NestedMapWithSliceIntValues(t *testing.T) {
 
 	foo := in["Foo"].(map[string][]int)
 	if name := foo["example_key"]; name[0] != 80 {
-		t.Errorf("Map nested struct's name field should give example, got: %s", name)
+		t.Errorf("Map nested struct's name field should give example, got: %v", name)
 	}
 }
 


### PR DESCRIPTION
Noticed while testing a projects that uses structs:

```
...
vendor/github.com/fatih/structs/structs_test.go:402:
    arg name for printf verb %s of wrong type: []int
...
```