### PR TITLE
add "values" tag option

### DIFF
--- a/structs_test.go
+++ b/structs_test.go
@@ -558,6 +558,63 @@ func TestMap_Anonymous(t *testing.T) {
 	}
 }
 
+func TestMap_ValuesSlice(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A []A `structs:",values"`
+		C int
+	}
+	b := &B{C: 123}
+	b.A = []A{a, a}
+
+	m := Map(b)
+
+	_, ok := m["A"].(map[string]interface{})
+	if ok {
+		t.Error("Embedded A struct with tag flatten has to be flat in the map")
+	}
+
+	expectedMap := map[string]interface{}{"A": []interface{}{
+		[]interface{}{"example"},
+		[]interface{}{"example"},
+	}, "C": 123}
+	if !reflect.DeepEqual(m, expectedMap) {
+		t.Errorf("The exprected map %+v does't correspond to %+v", expectedMap, m)
+	}
+
+}
+
+func TestMap_Values(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A `structs:",values"`
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	m := Map(b)
+
+	_, ok := m["A"].(map[string]interface{})
+	if ok {
+		t.Error("Embedded A struct with tag flatten has to be flat in the map")
+	}
+
+	expectedMap := map[string]interface{}{"A": []interface{}{"example"}, "C": 123}
+	if !reflect.DeepEqual(m, expectedMap) {
+		t.Errorf("The exprected map %+v does't correspond to %+v", expectedMap, m)
+	}
+
+}
+
 func TestMap_Flatnested(t *testing.T) {
 	type A struct {
 		Name string


### PR DESCRIPTION
A field of type struct is converted to a slice of that struct's values. The same happens for a field of type slice of structs.

For example,

```go
type A struct {
  Field  os.Process   `structs:",values"`
  Fields []os.Process `structs:",values"`
}
```

Example of an output:

```json
{
  "Field":  [0],
  "Fields": [[0], [0]]
}
```

Instead of 

```json
{
  "Field":  {"Pid": 0},
  "Fields": [{"Pid": 0}, {"Pid": 0}]
}
```