### PR TITLE
Create constructor that takes in a custom tag name

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -25,10 +25,16 @@ type Struct struct {
 // New returns a new *Struct with the struct s. It panics if the s's kind is
 // not struct.
 func New(s interface{}) *Struct {
+    return NewWithTagName(s, DefaultTagName)
+}
+
+// NewWithTagName returns a new *Struct with the struct s, and the provided tagName
+// It panics if the s's kind is not struct
+func NewWithTagName(s interface{}, tagName string) *Struct {
 	return &Struct{
 		raw:     s,
 		value:   strctVal(s),
-		TagName: DefaultTagName,
+		TagName: tagName,
 	}
 }
 

--- a/structs.go
+++ b/structs.go
@@ -524,8 +524,7 @@ func (s *Struct) nested(val reflect.Value) interface{} {
 
 	switch v.Kind() {
 	case reflect.Struct:
-		n := New(val.Interface())
-		n.TagName = s.TagName
+		n := NewWithTagName(val.Interface(), s.TagName)
 		m := n.Map()
 
 		// do not add the converted value if there are no exported fields, ie:

--- a/structs_test.go
+++ b/structs_test.go
@@ -128,8 +128,7 @@ func TestMap_CustomTag(t *testing.T) {
 	}
 	T.D.E = "e-value"
 
-	s := New(T)
-	s.TagName = "json"
+	s := NewWithTagName(T, "json")
 
 	a := s.Map()
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -168,15 +168,13 @@ func TestMap_MultipleCustomTag(t *testing.T) {
 		X string `aa:"ax"`
 	}{"a_value"}
 
-	aStruct := New(A)
-	aStruct.TagName = "aa"
+	aStruct := NewWithTagName(A, "aa")
 
 	var B = struct {
 		X string `bb:"bx"`
 	}{"b_value"}
 
-	bStruct := New(B)
-	bStruct.TagName = "bb"
+	bStruct := NewWithTagName(B, "bb")
 
 	a, b := aStruct.Map(), bStruct.Map()
 	if !reflect.DeepEqual(a, map[string]interface{}{"ax": "a_value"}) {
@@ -1339,9 +1337,7 @@ func TestTagWithStringOption(t *testing.T) {
 		}
 	}()
 
-	s := New(address)
-
-	s.TagName = "json"
+	s := NewWithTagName(address, "json")
 	m := s.Map()
 
 	if m["person"] != person.String() {

--- a/structs_test.go
+++ b/structs_test.go
@@ -1377,9 +1377,8 @@ func TestNonStringerTagWithStringOption(t *testing.T) {
 		}
 	}()
 
-	s := New(d)
+	s := NewWithTagname(d, "json")
 
-	s.TagName = "json"
 	m := s.Map()
 
 	if _, exists := m["animal"]; exists {

--- a/structs_test.go
+++ b/structs_test.go
@@ -1377,7 +1377,7 @@ func TestNonStringerTagWithStringOption(t *testing.T) {
 		}
 	}()
 
-	s := NewWithTagname(d, "json")
+	s := NewWithTagName(d, "json")
 
 	m := s.Map()
 


### PR DESCRIPTION
Currently, to use a custom tag name (like `json`), I need to do something like:
```
strct := structs.New(myStructHere)
strct.TagName = "json"
```
which is inconvenient. (I'm currently bringing in uses of `structs` in a large codebase.)

I would like to be able to do `structs.NewWithTagName("json")`. That's what this PR enables.