### PR TITLE
Bring ability to override field name to Names()

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -231,12 +231,21 @@ func (s *Struct) Fields() []*Field {
 //
 // It panics if s's kind is not struct.
 func (s *Struct) Names() []string {
-	fields := getFields(s.value, s.TagName)
+	fields := s.structFields()
 
 	names := make([]string, len(fields))
 
 	for i, field := range fields {
-		names[i] = field.Name()
+		tagName, _ := parseTag(field.Tag.Get(s.TagName))
+		if tagName == "-" {
+			continue
+		}
+
+		if tagName != "" {
+			field.Name = tagName
+		}
+
+		names[i] = field.Name
 	}
 
 	return names

--- a/structs_test.go
+++ b/structs_test.go
@@ -852,15 +852,17 @@ func TestNames(t *testing.T) {
 		A string
 		B int
 		C bool
+		D string `structs:"OVERRIDE"`
 	}{
 		A: "a-value",
 		B: 2,
 		C: true,
+		D: "b-value",
 	}
 
 	s := Names(T)
 
-	if len(s) != 3 {
+	if len(s) != 4 {
 		t.Errorf("Names should return a slice of len 3, got: %d", len(s))
 	}
 
@@ -873,7 +875,7 @@ func TestNames(t *testing.T) {
 		return false
 	}
 
-	for _, val := range []string{"A", "B", "C"} {
+	for _, val := range []string{"A", "B", "C", "OVERRIDE"} {
 		if !inSlice(val) {
 			t.Errorf("Names should have the value %v", val)
 		}


### PR DESCRIPTION
I found the tagName functionality from Map() useful so I ported it to Names(). 