### PR TITLE
Add `indirect` option

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -133,14 +133,15 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 
 		if tagOpts.Has("indirect") {
 			v := reflect.ValueOf(val.Interface())
+			// Only consider pointer variables
 			if v.Kind() == reflect.Ptr {
 				v = v.Elem()
+				// Ignore maps and structs to not break isSubStruct
 				if v.Kind() != reflect.Map || v.Kind() != reflect.Struct {
 					out[name] = v.Interface()
 					continue
 				}
 			}
-
 		}
 
 		if tagOpts.Has("string") {

--- a/structs.go
+++ b/structs.go
@@ -131,6 +131,18 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 			finalVal = val.Interface()
 		}
 
+		if tagOpts.Has("indirect") {
+			v := reflect.ValueOf(val.Interface())
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+				if v.Kind() != reflect.Map || v.Kind() != reflect.Struct {
+					out[name] = v.Interface()
+					continue
+				}
+			}
+
+		}
+
 		if tagOpts.Has("string") {
 			s, ok := val.Interface().(fmt.Stringer)
 			if ok {

--- a/structs.go
+++ b/structs.go
@@ -56,8 +56,12 @@ func New(s interface{}) *Struct {
 // the value. Example:
 //
 //   // The value will be the int value that the *int points to.
-//   // If the pointer is nil, it is ignored as if it also had omitempty
+//   // If the *int is nil, it is ignored as if it also had omitempty.
 //   Field *int `structs:"field,indirect"`
+//
+//   // The value will be the int value that the *int points to.
+//   // If the int is 0 (zero value for type), it is ommitted by omitempty
+//   Field *int `structs:"field,indirect,omitempty"`
 //
 // A tag value with the option of "flatten" used in a struct field is to flatten its fields
 // in the output map. Example:
@@ -113,14 +117,12 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 
 		if tagOpts.Has("indirect") {
 			v := reflect.ValueOf(val.Interface())
-			// Only consider pointer variables
+			// Only consider non-nil pointer variables
 			if v.Kind() == reflect.Ptr && !v.IsNil() {
-				v = v.Elem()
-				// Ignore maps and structs to not break isSubStruct
-				if v.Kind() != reflect.Map || v.Kind() != reflect.Struct {
-					val = v
-				}
+				// Dereferance pointer and treat as regular value
+				val = v.Elem()
 			} else if v.IsNil() {
+				// Ignore nil pointer values
 				continue
 			}
 		}

--- a/structs_test.go
+++ b/structs_test.go
@@ -145,7 +145,6 @@ func TestMap_Indirect(t *testing.T) {
 			t.Errorf("Map should have the value %v", val)
 		}
 	}
-
 }
 
 func TestMap_CustomTag(t *testing.T) {

--- a/structs_test.go
+++ b/structs_test.go
@@ -134,7 +134,6 @@ func TestMap_Indirect(t *testing.T) {
 	}
 
 	a := Map(T)
-	fmt.Println(a)
 
 	inMap := func(val interface{}) bool {
 		for _, v := range a {

--- a/structs_test.go
+++ b/structs_test.go
@@ -116,15 +116,21 @@ func TestMap_Tag(t *testing.T) {
 func TestMap_Indirect(t *testing.T) {
 	aVal := "a-value"
 	bVal := 2
-	cVal := true
+	cVal := 0
+	dVal := true
+	var eVal *int
 	var T = struct {
 		A *string `structs:",indirect"`
 		B *int    `structs:",indirect"`
-		C *bool   `structs:",indirect"`
+		C *int    `structs:",indirect"`
+		D *bool   `structs:",indirect"`
+		E *int    `structs:",indirect"` // nil pointer, should be omitted
 	}{
 		A: &aVal,
 		B: &bVal,
 		C: &cVal,
+		D: &dVal,
+		E: eVal,
 	}
 
 	a := Map(T)

--- a/structs_test.go
+++ b/structs_test.go
@@ -115,22 +115,25 @@ func TestMap_Tag(t *testing.T) {
 
 func TestMap_Indirect(t *testing.T) {
 	aVal := "a-value"
-	bVal := 2
-	cVal := 0
-	dVal := true
-	var eVal *int
+	bVal := ""
+	cVal := 2
+	dVal := 0
+	eVal := true
+	var fVal *int
 	var T = struct {
 		A *string `structs:",indirect"`
-		B *int    `structs:",indirect"`
+		B *string `structs:",indirect"` // Empty value should be included
 		C *int    `structs:",indirect"`
-		D *bool   `structs:",indirect"`
-		E *int    `structs:",indirect"` // nil pointer, should be omitted
+		D *int    `structs:",indirect,omitempty"` // Empty value should be omitted
+		E *bool   `structs:",indirect"`
+		F *int    `structs:",indirect"` // nil pointer, should be omitted
 	}{
 		A: &aVal,
 		B: &bVal,
 		C: &cVal,
 		D: &dVal,
-		E: eVal,
+		E: &eVal,
+		F: fVal,
 	}
 
 	a := Map(T)
@@ -145,11 +148,28 @@ func TestMap_Indirect(t *testing.T) {
 		return false
 	}
 
-	for _, val := range []interface{}{"a-value", 2, true} {
+	notInMap := func(val interface{}) bool {
+		for _, v := range a {
+			if reflect.DeepEqual(v, val) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	for _, val := range []interface{}{"a-value", "", 2, true} {
 		if !inMap(val) {
 			t.Errorf("Map should have the value %v", val)
 		}
 	}
+
+	for _, val := range []interface{}{0, fVal} {
+		if !notInMap(val) {
+			t.Errorf("Map should not have the value %v", val)
+		}
+	}
+
 }
 
 func TestMap_CustomTag(t *testing.T) {

--- a/structs_test.go
+++ b/structs_test.go
@@ -113,6 +113,41 @@ func TestMap_Tag(t *testing.T) {
 
 }
 
+func TestMap_Indirect(t *testing.T) {
+	aVal := "a-value"
+	bVal := 2
+	cVal := true
+	var T = struct {
+		A *string `structs:",indirect"`
+		B *int    `structs:",indirect"`
+		C *bool   `structs:",indirect"`
+	}{
+		A: &aVal,
+		B: &bVal,
+		C: &cVal,
+	}
+
+	a := Map(T)
+	fmt.Println(a)
+
+	inMap := func(val interface{}) bool {
+		for _, v := range a {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, val := range []interface{}{"a-value", 2, true} {
+		if !inMap(val) {
+			t.Errorf("Map should have the value %v", val)
+		}
+	}
+
+}
+
 func TestMap_CustomTag(t *testing.T) {
 	var T = struct {
 		A string `json:"x"`


### PR DESCRIPTION
I needed to convert a struct generated by [protocol buffers](https://developers.google.com/protocol-buffers/docs/reference/go-generated#singular-scalar-proto2) where every field is a pointer to the actual value into a map of the actual values, omitting nil pointers that are not set.
For example, I want this:
```
type Data struct {
		A *string `structs:",indirect"`
		B *int    `structs:",indirect"`
}
```
to become, where A is a pointer to "a-value" and B is a pointer to 2, this (in string form):
```
map[A:a-value B:2]
```
or this, where A is a pointer to "a-value" and B is a nil pointer:
```
map[A:a-value]
```

Because I needed this functionality for another project (putting data from a protocol buffer into influxdb, which wants map[string]interface{}), I implemented this in FillMap, documented it, and wrote tests for it. Given that this seems like something someone would naturally want to do with a generated protocol buffer, I figured it might be worth upstreaming. So if it sounds interesting, please let me know if you have any concerns with my implementation or ideas for better ways to integrate this functionality with the library so I can make those changes, as I'd love for the the library to do this.