### PR TITLE
Add an option to flatten all anonymous structs in map

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -17,9 +17,10 @@ var (
 // Struct encapsulates a struct type to provide several high level functions
 // around the struct.
 type Struct struct {
-	raw     interface{}
-	value   reflect.Value
-	TagName string
+	raw              interface{}
+	value            reflect.Value
+	TagName          string
+	FlattenAnonymous bool
 }
 
 // New returns a new *Struct with the struct s. It panics if the s's kind is
@@ -139,7 +140,7 @@ func (s *Struct) FillMap(out map[string]interface{}) {
 			continue
 		}
 
-		if isSubStruct && (tagOpts.Has("flatten")) {
+		if isSubStruct && (tagOpts.Has("flatten") || (field.Anonymous && s.FlattenAnonymous)) {
 			for k := range finalVal.(map[string]interface{}) {
 				out[k] = finalVal.(map[string]interface{})[k]
 			}

--- a/structs_test.go
+++ b/structs_test.go
@@ -612,6 +612,32 @@ func TestMap_FlatnestedOverwrite(t *testing.T) {
 	}
 }
 
+func TestMap_FlattenAnonymous(t *testing.T) {
+	type A struct {
+		ID uint
+	}
+	a := A{ID: 10}
+
+	type B struct {
+		A
+		Name string
+	}
+	b := &B{A: a, Name: "bName"}
+
+	s := New(b)
+
+	m := s.Map()
+	if _, exist := m["A"]; !exist {
+		t.Error("Embedded A struct without tag flatten has to be nested in the map")
+	}
+
+	s.FlattenAnonymous = true
+	m = s.Map()
+	if _, exist := m["ID"]; !exist {
+		t.Error("Embedded A struct without tag flatten has to be flat in the map")
+	}
+}
+
 func TestMap_TimeField(t *testing.T) {
 	type A struct {
 		CreatedAt time.Time


### PR DESCRIPTION
Flatten anonymous structs in map without write `struct:",flatten"` everywhere by enable `FlattenAnonymous`